### PR TITLE
open serial port before setting it

### DIFF
--- a/Configurator/serialthread.cpp
+++ b/Configurator/serialthread.cpp
@@ -74,7 +74,9 @@ void SerialThread::run()
         return;
     }
 
+    emit this->serialConnected();
     qDebug() << "Serial Thread is ready...";
+
     m_mutex.lock();
     /* Unlock resources and wait for the first job. */
     m_cond.wait(&m_mutex);

--- a/Configurator/serialthread.cpp
+++ b/Configurator/serialthread.cpp
@@ -54,17 +54,18 @@ void SerialThread::run()
     int cr;
 
     serial.setPortName(m_portName);
-    serial.setBaudRate(57600);
-    serial.setDataBits(QSerialPort::Data8);
-    serial.setParity(QSerialPort::NoParity);
-    serial.setStopBits(QSerialPort::OneStop);
-    serial.setFlowControl(QSerialPort::NoFlowControl);
-
     for (cr = 0; cr < m_connectAttempts; cr++) {
-        if (serial.open(QIODevice::ReadWrite))
+        if (serial.open(QIODevice::ReadWrite)) {
+            serial.setBaudRate(57600);
+            serial.setDataBits(QSerialPort::Data8);
+            serial.setParity(QSerialPort::NoParity);
+            serial.setStopBits(QSerialPort::OneStop);
+            serial.setFlowControl(QSerialPort::NoFlowControl);
             break;
-        sleep(1);
-        qDebug() << "Serial connect retry...";
+        } else {
+            sleep(1);
+            qDebug() << "Serial connect retry...";
+        }
     }
     if (cr == m_connectAttempts) {
         qDebug() << "Connection failed!";
@@ -75,7 +76,6 @@ void SerialThread::run()
 
     emit this->serialConnected();
     qDebug() << "Serial Thread is ready...";
-
     m_mutex.lock();
     /* Unlock resources and wait for the first job. */
     m_cond.wait(&m_mutex);

--- a/Configurator/serialthread.cpp
+++ b/Configurator/serialthread.cpp
@@ -9,9 +9,10 @@
 
 QT_USE_NAMESPACE
 
-SerialThread::SerialThread(QObject *parent) :
+SerialThread::SerialThread(QObject *parent, int connectAttempts) :
     QThread(parent),
-    m_quit(false)
+    m_quit(false),
+    m_connectAttempts(connectAttempts)
 {
 
 }
@@ -50,9 +51,9 @@ void SerialThread::disconnect()
 void SerialThread::run()
 {
     QSerialPort serial;
+    int cr;
 
     serial.setPortName(m_portName);
-<<<<<<< HEAD
     for (cr = 0; cr < m_connectAttempts; cr++) {
         if (serial.open(QIODevice::ReadWrite)) {
             serial.setBaudRate(57600);
@@ -67,15 +68,6 @@ void SerialThread::run()
         }
     }
     if (cr == m_connectAttempts) {
-=======
-    if (serial.open(QIODevice::ReadWrite)) {
-        serial.setBaudRate(57600);
-        serial.setDataBits(QSerialPort::Data8);
-        serial.setParity(QSerialPort::NoParity);
-        serial.setStopBits(QSerialPort::OneStop);
-        serial.setFlowControl(QSerialPort::NoFlowControl);
-    } else {
->>>>>>> 72c0912197cbba4200d05dc6ec47d0a3ccea2275
         qDebug() << "Connection failed!";
         emit this->serialError(tr("Can't open %1, error code %2. %3.")
             .arg(m_portName).arg(serial.error()).arg(serial.errorString()));


### PR DESCRIPTION
On linux systems, serial.open() is needed before any other operations. 